### PR TITLE
Simplify playground preview layout

### DIFF
--- a/src/components/playground/PreviewPanel.tsx
+++ b/src/components/playground/PreviewPanel.tsx
@@ -63,138 +63,82 @@ export const PreviewPanel = ({ config }: PreviewPanelProps) => {
 
       <div className="relative flex flex-1 flex-col items-center justify-center overflow-hidden px-4 pb-8 pt-6 sm:px-8">
         <div
-          className="relative flex w-full max-w-[520px] flex-col rounded-[36px] bg-white shadow-2xl ring-1 ring-black/5"
+          className="relative flex w-full max-w-[520px] flex-1 flex-col rounded-[36px] bg-white p-6 sm:p-8 shadow-2xl ring-1 ring-black/5"
           style={{
             background: surfaceBackground,
           }}
         >
           <div className="absolute inset-0 -z-10 rounded-[36px] bg-gradient-to-br from-white/40 via-white/10 to-black/10 blur-3xl" />
-          <div className="flex flex-col gap-4 rounded-[36px] p-6 sm:p-8">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <span
-                  className="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/30 text-lg font-semibold text-neutral-900 shadow"
-                  style={{ color: config.accentColor }}
-                >
-                  ✨
-                </span>
-                <div>
-                  <p className="text-xs uppercase tracking-wide text-neutral-600">
-                    Start screen
-                  </p>
-                  <p className="text-sm font-semibold text-neutral-800">
-                    {config.startScreen.greeting}
-                  </p>
-                </div>
-              </div>
-              <div className="text-xs text-neutral-500">Preview</div>
-            </div>
-
-            <ul className="flex flex-col gap-2 rounded-3xl bg-white/60 p-4 text-sm text-neutral-600 shadow-inner">
-              {config.startScreen.starterPrompts.slice(0, 4).map((prompt) => (
-                <li
-                  key={prompt}
-                  className="flex items-center gap-3 rounded-2xl bg-white/90 px-3 py-2 shadow-sm"
-                >
-                  <span className="text-neutral-400">●</span>
-                  <span className="text-neutral-700">{prompt}</span>
-                </li>
-              ))}
-              {config.startScreen.starterPrompts.length === 0 && (
-                <li className="rounded-2xl border border-dashed border-neutral-300 px-3 py-3 text-center text-xs text-neutral-400">
-                  No starter prompts configured.
-                </li>
-              )}
-            </ul>
-          </div>
-
-          <div className="relative mt-4 flex flex-col rounded-t-[32px] bg-white/80 px-4 pb-8 pt-6 shadow-[0_-10px_45px_-20px_rgba(15,23,42,0.25)]">
-            <div className="mb-4 flex items-center justify-between px-2">
-              <div className="flex items-center gap-2">
-                <div
-                  className="h-2 w-2 rounded-full"
-                  style={{
-                    backgroundColor: config.accentColor,
-                  }}
-                />
-                <p className="text-xs font-medium text-neutral-500">
-                  Copilot preview
-                </p>
-              </div>
-              <span className="text-xs text-neutral-400">Live</span>
-            </div>
-
-            <div
-              className="playground-preview relative overflow-hidden rounded-[28px] border border-neutral-200 bg-white shadow-lg"
-              style={styleVariables}
-            >
-              {(config.options.modelPicker ||
-                config.options.toolMenu.searchDocs ||
-                config.options.toolMenu.createTheme) && (
-                <div className="pointer-events-none absolute inset-x-4 top-4 flex items-center justify-between text-[11px] uppercase tracking-wider text-neutral-400">
-                  {config.options.modelPicker ? (
-                    <div
-                      className="pointer-events-auto rounded-full bg-neutral-900 px-3 py-1 text-[11px] font-medium text-white shadow"
-                      style={{ backgroundColor: config.accentColor }}
-                    >
-                      Model · gpt-4o-mini
-                    </div>
-                  ) : (
-                    <span />
-                  )}
-                  <div className="flex gap-2">
-                    {config.options.toolMenu.searchDocs && (
-                      <span className="rounded-full border border-neutral-300 bg-white/90 px-3 py-1 text-[11px] font-medium text-neutral-500 shadow-sm">
-                        Search docs
-                      </span>
-                    )}
-                    {config.options.toolMenu.createTheme && (
-                      <span className="rounded-full border border-neutral-300 bg-white/90 px-3 py-1 text-[11px] font-medium text-neutral-500 shadow-sm">
-                        Create theme
-                      </span>
-                    )}
+          <div
+            className="playground-preview relative flex-1 overflow-hidden rounded-[28px] border border-neutral-200 bg-white shadow-lg"
+            style={styleVariables}
+          >
+            {(config.options.modelPicker ||
+              config.options.toolMenu.searchDocs ||
+              config.options.toolMenu.createTheme) && (
+              <div className="pointer-events-none absolute inset-x-4 top-4 flex items-center justify-between text-[11px] uppercase tracking-wider text-neutral-400">
+                {config.options.modelPicker ? (
+                  <div
+                    className="pointer-events-auto rounded-full bg-neutral-900 px-3 py-1 text-[11px] font-medium text-white shadow"
+                    style={{ backgroundColor: config.accentColor }}
+                  >
+                    Model · gpt-4o-mini
                   </div>
-                </div>
-              )}
-              <CopilotChat
-                className="playground-preview-chat"
-                labels={{
-                  title: "Playground Copilot",
-                  placeholder: config.composer.placeholder,
-                  initial: config.startScreen.greeting,
-                }}
-                imageUploadsEnabled={config.composer.attachments}
-                RenderSuggestionsList={(props) => (
-                  <PreviewSuggestions
-                    {...props}
-                    fallback={fallbackSuggestions}
-                  />
+                ) : (
+                  <span />
                 )}
-                Input={(props) => (
-                  <PreviewComposer
-                    {...props}
-                    disclaimer={config.composer.disclaimer}
-                    density={config.style.density}
-                    attachmentsEnabled={config.composer.attachments}
-                  />
-                )}
-              />
-              {(config.options.messageActions.copy ||
-                config.options.messageActions.share) && (
-                <div className="pointer-events-none absolute bottom-4 right-4 flex gap-2 text-[11px] font-medium text-neutral-400">
-                  {config.options.messageActions.copy && (
-                    <span className="rounded-full bg-neutral-900/10 px-3 py-1">
-                      Copy action
+                <div className="flex gap-2">
+                  {config.options.toolMenu.searchDocs && (
+                    <span className="rounded-full border border-neutral-300 bg-white/90 px-3 py-1 text-[11px] font-medium text-neutral-500 shadow-sm">
+                      Search docs
                     </span>
                   )}
-                  {config.options.messageActions.share && (
-                    <span className="rounded-full bg-neutral-900/10 px-3 py-1">
-                      Share action
+                  {config.options.toolMenu.createTheme && (
+                    <span className="rounded-full border border-neutral-300 bg-white/90 px-3 py-1 text-[11px] font-medium text-neutral-500 shadow-sm">
+                      Create theme
                     </span>
                   )}
                 </div>
+              </div>
+            )}
+            <CopilotChat
+              className="playground-preview-chat"
+              labels={{
+                title: "Playground Copilot",
+                placeholder: config.composer.placeholder,
+                initial: config.startScreen.greeting,
+              }}
+              imageUploadsEnabled={config.composer.attachments}
+              RenderSuggestionsList={(props) => (
+                <PreviewSuggestions
+                  {...props}
+                  fallback={fallbackSuggestions}
+                />
               )}
-            </div>
+              Input={(props) => (
+                <PreviewComposer
+                  {...props}
+                  disclaimer={config.composer.disclaimer}
+                  density={config.style.density}
+                  attachmentsEnabled={config.composer.attachments}
+                />
+              )}
+            />
+            {(config.options.messageActions.copy ||
+              config.options.messageActions.share) && (
+              <div className="pointer-events-none absolute bottom-4 right-4 flex gap-2 text-[11px] font-medium text-neutral-400">
+                {config.options.messageActions.copy && (
+                  <span className="rounded-full bg-neutral-900/10 px-3 py-1">
+                    Copy action
+                  </span>
+                )}
+                {config.options.messageActions.share && (
+                  <span className="rounded-full bg-neutral-900/10 px-3 py-1">
+                    Share action
+                  </span>
+                )}
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove the static start screen preview from the playground panel
- promote the Copilot chat preview so it fills the card while retaining styling hooks

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68e469ce757883278df72555b74fcea0